### PR TITLE
Upgrade nom from v7 to v8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ bitflags = "2.6.0"
 byteorder = "1.5"
 bytes = "1.9"
 ipnet = { version = "2.10", features = ["serde"] }
-nom = "7"
-nom-derive = "0.10"
+nom = "8"
+nom-derive = { git = "https://github.com/rust-bakery/nom-derive", branch = "master" }
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/attr/aspath.rs
+++ b/src/attr/aspath.rs
@@ -39,14 +39,14 @@ pub struct As2Path {
 
 impl ParseBe<As2Path> for As2Path {
     fn parse_be(input: &[u8]) -> IResult<&[u8], As2Path> {
-        let (input, segs) = many0(parse_bgp_attr_as2_segment)(input)?;
+        let (input, segs) = many0(parse_bgp_attr_as2_segment).parse(input)?;
         Ok((input, As2Path { segs }))
     }
 }
 
 fn parse_bgp_attr_as2_segment(input: &[u8]) -> IResult<&[u8], As2Segment> {
-    let (input, header) = AsSegmentHeader::parse(input)?;
-    let (input, asns) = count(be_u16, header.length as usize)(input)?;
+    let (input, header) = AsSegmentHeader::parse_be(input)?;
+    let (input, asns) = count(be_u16, header.length as usize).parse(input)?;
     let segment = As2Segment {
         typ: header.typ,
         asn: asns.into_iter().collect(),
@@ -55,8 +55,8 @@ fn parse_bgp_attr_as2_segment(input: &[u8]) -> IResult<&[u8], As2Segment> {
 }
 
 fn parse_bgp_attr_as4_segment(input: &[u8]) -> IResult<&[u8], As4Segment> {
-    let (input, header) = AsSegmentHeader::parse(input)?;
-    let (input, asns) = count(be_u32, header.length as usize)(input)?;
+    let (input, header) = AsSegmentHeader::parse_be(input)?;
+    let (input, asns) = count(be_u32, header.length as usize).parse(input)?;
     let segment = As4Segment {
         typ: header.typ,
         asn: asns.into_iter().collect(),
@@ -138,7 +138,7 @@ impl AttrEmitter for As4Path {
 
 impl ParseBe<As4Path> for As4Path {
     fn parse_be(input: &[u8]) -> IResult<&[u8], As4Path> {
-        let (input, segs) = many0(parse_bgp_attr_as4_segment)(input)?;
+        let (input, segs) = many0(parse_bgp_attr_as4_segment).parse(input)?;
         Ok((input, As4Path { segs: segs.into() }))
     }
 }

--- a/src/cap/fqdn.rs
+++ b/src/cap/fqdn.rs
@@ -41,10 +41,10 @@ impl Emit for CapabilityFqdn {
 impl CapabilityFqdn {
     pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, hostname_len) = be_u8(input)?;
-        let (input, hostname) = take(hostname_len)(input)?;
+        let (input, hostname) = take(hostname_len).parse(input)?;
         let hostname = hostname.to_vec();
         let (input, domain_len) = be_u8(input)?;
-        let (input, domain) = take(domain_len)(input)?;
+        let (input, domain) = take(domain_len).parse(input)?;
         let domain = domain.to_vec();
 
         let fqdn = Self { hostname, domain };


### PR DESCRIPTION
## Summary
- Upgrade nom parser from v7 to v8
- Update nom-derive to use master branch from GitHub (v8 compatible)
- Fix parser syntax changes required by nom v8 (adding `.parse()` calls)

## Changes
- Updated `Cargo.toml` dependencies
- Modified parser calls throughout codebase to use new nom v8 syntax
- All parser combinators now require explicit `.parse()` method calls
- Updated `ParseBe` trait implementations to use `parse_be` methods

## Test plan
- [ ] Run `make test` to ensure all tests pass
- [ ] Run `cargo clippy` to check for linting issues
- [ ] Verify parser functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)