### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 
 
 [dependencies]
-bitfield-struct = "0.9"
+bitfield-struct = "0.11.0"
 bitflags = "2.6.0"
 byteorder = "1.5"
 bytes = "1.9"
@@ -34,4 +34,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
-hex-literal = "0.3"
+hex-literal = "1.0"


### PR DESCRIPTION
## Summary
- Upgrade bitfield-struct from v0.9 to v0.11.0
- Upgrade hex-literal from v0.3 to v1.0

## Changes
- Updated `Cargo.toml` with latest compatible versions
- All existing functionality remains unchanged

## Test plan
- [x] Run `cargo build` - builds successfully
- [x] Run `make test` - all 16 tests pass
- [x] Run `cargo clippy` - no linting issues

🤖 Generated with [Claude Code](https://claude.ai/code)