### PR TITLE
Add EVPN NLRI support and improve display formatting

### DIFF
--- a/src/attr/rd.rs
+++ b/src/attr/rd.rs
@@ -5,14 +5,14 @@ use std::str::FromStr;
 
 #[allow(clippy::upper_case_acronyms)]
 #[repr(u16)]
-#[derive(Default, NomBE, PartialEq, Debug)]
+#[derive(Default, NomBE, PartialEq, Debug, Clone)]
 pub enum RouteDistinguisherType {
     #[default]
     ASN = 0,
     IP = 1,
 }
 
-#[derive(Default, NomBE, PartialEq, Debug)]
+#[derive(Default, NomBE, PartialEq, Debug, Clone)]
 pub struct RouteDistinguisher {
     pub typ: RouteDistinguisherType,
     pub val: [u8; 6],

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use std::fmt::Display;
 
 use super::attr::{
     Aggregator2, Aggregator4, Aigp, As2Path, As4Path, AtomicAggregate, AttributeFlags, Community,
@@ -162,6 +163,15 @@ impl Attr {
     }
 }
 
+impl Display for Attr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Attr::Origin(v) => write!(f, "{}", v),
+            _ => write!(f, "Attr"),
+        }
+    }
+}
+
 fn parse_bgp_attribute(input: &[u8], as4: bool) -> IResult<&[u8], Attr> {
     // Parse the attribute flags and type code
     let (input, flags_byte) = be_u8(input)?;
@@ -317,7 +327,9 @@ pub fn parse_bgp_packet(input: &[u8], as4: bool) -> IResult<&[u8], BgpPacket> {
             let (input, p) = parse_bgp_update_packet(input, as4)?;
             Ok((input, BgpPacket::Update(p)))
         }
-        BgpType::Notification => map(parse_bgp_notification_packet, BgpPacket::Notification).parse(input),
+        BgpType::Notification => {
+            map(parse_bgp_notification_packet, BgpPacket::Notification).parse(input)
+        }
         BgpType::Keepalive => map(BgpHeader::parse_be, BgpPacket::Keepalive).parse(input),
         _ => Err(nom::Err::Error(make_error(input, ErrorKind::Eof))),
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::Attr;
 
 use super::{BgpHeader, BgpType, BGP_HEADER_LEN};
@@ -29,5 +31,15 @@ impl Default for UpdatePacket {
             ipv4_update: Vec::new(),
             ipv4_withdraw: Vec::new(),
         }
+    }
+}
+
+impl Display for UpdatePacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Update")?;
+        for attr in self.attrs.iter() {
+            writeln!(f, "{}", attr)?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add EVPN (Ethernet VPN) NLRI support to the BGP packet parser
- Improve display formatting for BGP attributes and update packets
- Make necessary types cloneable for better usability

## Changes
- Add `evpn_prefix` field to `MpNlriReachAttr` to store EVPN prefixes
- Add `snpa` field to `MpNlriReachAttr` 
- Make `Evpn` and `RouteDistinguisher` types implement `Clone`
- Add `rd()` getter method to `Evpn` struct
- Implement `Display` trait for `Attr` and `UpdatePacket` for better debugging
- Support both IPv4 (4 bytes) and IPv6 (16 bytes) nexthop lengths for EVPN
- Use `Default` trait for cleaner `MpNlriReachAttr` initialization

## Test plan
- [x] Run `cargo build` - builds successfully
- [x] Run `make test` - all tests pass
- [x] Run `cargo clippy` - no linting issues

🤖 Generated with [Claude Code](https://claude.ai/code)