### PR TITLE
Fix build errors after merge

### DIFF
--- a/src/attr/attribute.rs
+++ b/src/attr/attribute.rs
@@ -27,7 +27,7 @@ pub struct MpNlriUnreachHeader {
     pub safi: Safi,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub struct MpNlriReachAttr {
     pub snpa: u8,
     pub next_hop: Option<Ipv6Addr>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,6 @@
 use std::convert::TryInto;
-<<<<<<< HEAD
 use std::fmt;
-=======
 use std::fmt::Display;
->>>>>>> origin/main
 
 use super::attr::{
     Aggregator2, Aggregator4, Aigp, As2Path, As4Path, AtomicAggregate, AttributeFlags, Community,


### PR DESCRIPTION
## Summary
- Fix build errors that occurred after merging PR #6
- Remove remaining merge conflict markers
- Resolve duplicate Debug trait implementation

## Changes
- Remove remaining merge conflict marker in `parser.rs` 
- Fix duplicate Debug trait implementation for `MpNlriReachAttr` by removing the derived Debug
- Import both `fmt` and `fmt::Display` in parser.rs

## Test plan
- [x] Run `cargo build` - builds successfully
- [x] Run `make test` - all 16 tests pass

This fixes the build errors that were introduced during the merge conflict resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)