### PR TITLE
Add L2VPN/EVPN support to MP-Unreach NLRI parsing

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,11 +12,11 @@ use super::attr::{
 use super::*;
 use bytes::BytesMut;
 use ipnet::{Ipv4Net, Ipv6Net};
+use nom::IResult;
 use nom::bytes::complete::take;
 use nom::combinator::peek;
-use nom::error::{make_error, ErrorKind};
-use nom::number::complete::{be_u16, be_u32, be_u8};
-use nom::IResult;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom_derive::*;
 use std::net::{Ipv4Addr, Ipv6Addr};
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -4,13 +4,17 @@ use hex_literal::hex;
 fn parse(buf: &[u8]) {
     // Parse with AS4 = truue.
     let packet = parse_bgp_packet(buf, true);
-    match packet {
-        Ok(_) => {
-            println!("parse success");
+    assert!(packet.is_ok());
+
+    let (_, packet) = packet.unwrap();
+    if let BgpPacket::Update(update) = packet {
+        for attr in update.attrs.iter() {
+            if let Attr::MpUnreachNlri(unreach) = attr {
+                assert!(unreach.evpn_prefix.len() == 1);
+            }
         }
-        Err(err) => {
-            println!("parse error {}", err);
-        }
+    } else {
+        panic!("Packet must be Update");
     }
 }
 


### PR DESCRIPTION
## Summary
- Add support for parsing L2VPN/EVPN routes in MP-Unreach NLRI attributes
- Enable proper handling of EVPN route withdrawals in BGP protocol

## Changes

### Enhanced MP-Unreach Structure
- Added `evpn_prefix` field to `MpNlriUnreachAttr` struct to store EVPN routes
- Implemented `Default` trait for cleaner struct initialization

### Parser Improvements
- Extended MP-Unreach parser to handle multiple AFI/SAFI combinations:
  - **IPv6/Unicast**: Parses IPv6 prefix withdrawals
  - **L2VPN/EVPN**: Parses EVPN NLRI withdrawals
- Refactored conditional logic for better readability
- Added debug logging for parsed EVPN routes
- Returns appropriate error for unsupported AFI/SAFI combinations

### Testing
- Updated parser tests to verify EVPN unreach parsing
- Added assertion to check that EVPN prefixes are correctly parsed

## Use Case
This change is essential for BGP implementations that need to:
- Handle EVPN route withdrawals in data center environments
- Support L2VPN/EVPN AFI/SAFI for MP-BGP operations
- Process MP-Unreach NLRI attributes for EVPN routes

## Test Plan
- [x] Run `make format` to ensure code formatting
- [x] Run `cargo build` - builds successfully  
- [x] Run `make test` - all tests pass
- [x] Run `cargo clippy` - no linting issues
- [x] Verify EVPN unreach parsing in test assertions

🤖 Generated with [Claude Code](https://claude.ai/code)